### PR TITLE
Make destination optional in sendPrintRequest

### DIFF
--- a/client/printing/print_client.js
+++ b/client/printing/print_client.js
@@ -19,7 +19,7 @@ function healthCheck() {
   });
 }
 
-function sendPrintRequest(raw, copies, sides, pageRanges, destination) {
+function sendPrintRequest(raw, copies, sides, pageRanges, destination='') {
   printOptions = {
     'sides': sides,
     'page-ranges': pageRanges


### PR DESCRIPTION
Destination is no long used in the front end. Temporary fix until I can get into the club room to test this whole thing